### PR TITLE
Update ConnectedMtpDevices.cpp to prevent segfault when working with unknown devices

### DIFF
--- a/src/ConnectedMtpDevices.cpp
+++ b/src/ConnectedMtpDevices.cpp
@@ -92,10 +92,22 @@ ConnectedDeviceInfo	ConnectedMtpDevices::GetDeviceInfo(int index)
 	ConnectedDeviceInfo info;
 	info.bus_location = m_devs[index].bus_location;
 	info.devnum = m_devs[index].devnum;
-	info.device_flags = m_devs[index].device_entry.device_flags;
-	info.product = m_devs[index].device_entry.product;
+	if (m_devs[index].device_entry.device_flags > 0){
+		info.device_flags = m_devs[index].device_entry.device_flags;
+	} else {
+		info.device_flags = 0;
+	}
+	if (m_devs[index].device_entry.product != NULL){
+		info.product = m_devs[index].device_entry.product;
+	} else {
+		info.product = "unknown";
+	}
 	info.product_id = m_devs[index].device_entry.product_id;
-	info.vendor = m_devs[index].device_entry.vendor;
+	if (m_devs[index].device_entry.vendor != NULL){
+		info.vendor = m_devs[index].device_entry.vendor;
+	} else {
+		info.vendor = "unknown";
+	}
 	info.vendor_id = m_devs[index].device_entry.vendor_id;
 
 	return info;


### PR DESCRIPTION
On my system (FreeBSD-12/LLVM-10), attempts to list available devices and to mount a specific device fail with a segfault if any attached devices are "UNKNOWN in libmtp":

```
# jmtpfs -l
Device 0 (VID=2080 and PID=000c) is UNKNOWN in libmtp v1.1.18.
Please report this VID/PID and the device model to the libmtp development team
zsh: segmentation fault (core dumped)  jmtpfs -l

# jmtpfs -device=1,7 /mnt/nook
Device 0 (VID=2080 and PID=000c) is UNKNOWN in libmtp v1.1.18.
Please report this VID/PID and the device model to the libmtp development team
zsh: segmentation fault (core dumped)  jmtpfs -device=1,7 /mnt/nook

# jmtpfs /mnt/nook
Device 0 (VID=2080 and PID=000c) is UNKNOWN in libmtp v1.1.18.
Please report this VID/PID and the device model to the libmtp development team
Android device detected, assigning default bug flags
```

With this patch applied, all operations appear to work as expected:

```
# jmtpfs -l
Device 0 (VID=2080 and PID=000c) is UNKNOWN in libmtp v1.1.18.
Please report this VID/PID and the device model to the libmtp development team
Available devices (busLocation, devNum, productId, vendorId, product, vendor):
1, 7, 0x000c, 0x2080, unknown, unknown

# jmtpfs -device=1,7 /mnt/nook
Device 0 (VID=2080 and PID=000c) is UNKNOWN in libmtp v1.1.18.
Please report this VID/PID and the device model to the libmtp development team
Android device detected, assigning default bug flags

# jmtpfs /mnt/nook
Device 0 (VID=2080 and PID=000c) is UNKNOWN in libmtp v1.1.18.
Please report this VID/PID and the device model to the libmtp development team
Android device detected, assigning default bug flags
```


My system details:
```
$ c++ --version
FreeBSD clang version 10.0.1 (git@github.com:llvm/llvm-project.git llvmorg-10.0.1-0-gef32c611aa2)
Target: x86_64-unknown-freebsd12.2
Thread model: posix
InstalledDir: /usr/bin

$ uname -v
FreeBSD 12.2-STABLE #3 r368820M: Tue Dec 22 02:29:28 PST 2020
```
